### PR TITLE
Add table namespaces with grouping and casting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
+pub mod bloom;
+pub mod memtable;
+pub mod query;
+pub mod sstable;
 pub mod storage;
 pub mod wal;
-pub mod memtable;
-pub mod sstable;
-pub mod bloom;
 pub mod zonemap;
-pub mod query;
 
 pub use query::SqlEngine;
 
@@ -19,7 +19,10 @@ impl<S: storage::Storage> Database<S> {
     /// Create a new database instance backed by the provided storage
     /// implementation.
     pub fn new(storage: S) -> Self {
-        Self { storage, memtable: memtable::MemTable::new() }
+        Self {
+            storage,
+            memtable: memtable::MemTable::new(),
+        }
     }
 
     /// Return a reference to the configured storage backend.
@@ -40,5 +43,58 @@ impl<S: storage::Storage> Database<S> {
     /// Retrieve the value associated with `key`, if it exists.
     pub async fn get(&self, key: &str) -> Option<Vec<u8>> {
         self.memtable.get(key).await
+    }
+
+    /// Delete a key from the database.
+    pub async fn delete(&self, key: &str) {
+        self.memtable.delete(key).await;
+    }
+
+    /// Return all key/value pairs currently stored.
+    pub async fn scan(&self) -> Vec<(String, Vec<u8>)> {
+        self.memtable.scan().await
+    }
+
+    /// Remove all data from the in-memory table.
+    pub async fn clear(&self) {
+        self.memtable.clear().await;
+    }
+
+    /// Insert a key/value pair into the provided namespace.
+    pub async fn insert_ns(&self, ns: &str, key: String, value: Vec<u8>) {
+        let namespaced = format!("{}:{}", ns, key);
+        self.memtable.insert(namespaced, value).await;
+    }
+
+    /// Retrieve a value from the given namespace.
+    pub async fn get_ns(&self, ns: &str, key: &str) -> Option<Vec<u8>> {
+        let namespaced = format!("{}:{}", ns, key);
+        self.memtable.get(&namespaced).await
+    }
+
+    /// Delete a key within the specified namespace.
+    pub async fn delete_ns(&self, ns: &str, key: &str) {
+        let namespaced = format!("{}:{}", ns, key);
+        self.memtable.delete(&namespaced).await;
+    }
+
+    /// Scan all key/value pairs for a namespace, stripping the prefix.
+    pub async fn scan_ns(&self, ns: &str) -> Vec<(String, Vec<u8>)> {
+        let prefix = format!("{}:", ns);
+        self.memtable
+            .scan()
+            .await
+            .into_iter()
+            .filter_map(|(k, v)| {
+                k.strip_prefix(&prefix)
+                    .map(|rest| (rest.to_string(), v))
+            })
+            .collect()
+    }
+
+    /// Clear all data for a namespace.
+    pub async fn clear_ns(&self, ns: &str) {
+        let prefix = format!("{}:", ns);
+        self.memtable.delete_prefix(&prefix).await;
     }
 }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -7,7 +7,9 @@ pub struct MemTable {
 
 impl MemTable {
     pub fn new() -> Self {
-        Self { data: RwLock::new(BTreeMap::new()) }
+        Self {
+            data: RwLock::new(BTreeMap::new()),
+        }
     }
 
     pub async fn insert(&self, key: String, value: Vec<u8>) {
@@ -16,5 +18,34 @@ impl MemTable {
 
     pub async fn get(&self, key: &str) -> Option<Vec<u8>> {
         self.data.read().await.get(key).cloned()
+    }
+
+    pub async fn delete(&self, key: &str) {
+        self.data.write().await.remove(key);
+    }
+
+    pub async fn scan(&self) -> Vec<(String, Vec<u8>)> {
+        self.data
+            .read()
+            .await
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+
+    pub async fn clear(&self) {
+        self.data.write().await.clear();
+    }
+
+    pub async fn delete_prefix(&self, prefix: &str) {
+        let mut data = self.data.write().await;
+        let keys: Vec<String> = data
+            .keys()
+            .filter(|k| k.starts_with(prefix))
+            .cloned()
+            .collect();
+        for k in keys {
+            data.remove(&k);
+        }
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -84,7 +84,6 @@ impl SqlEngine {
                 register_table(db, &ns).await;
                 Ok(None)
             }
-            Statement::CreateDatabase { .. } => Ok(None),
             Statement::ShowTables { .. } => self.exec_show_tables(db).await,
             Statement::Drop {
                 object_type: ObjectType::Table,

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,13 @@
 //! Minimal SQL execution engine for the key-value store.
 
-use sqlparser::ast::{BinaryOperator, Expr, SetExpr, Statement, Value};
+use std::collections::BTreeMap;
+
+use sqlparser::ast::{
+    Assignment, AssignmentTarget, BinaryOperator, DataType, Delete, Expr, FromTable, Function,
+    FunctionArg, FunctionArgExpr, FunctionArguments, Insert, LimitClause, ObjectName,
+    ObjectType, OrderBy, OrderByKind, Query, Select, SelectItem, SetExpr, Statement,
+    TableFactor, TableWithJoins, Value,
+};
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
 
@@ -17,8 +24,7 @@ pub enum QueryError {
     Unsupported,
 }
 
-/// Simple SQL engine capable of executing a subset of INSERT and SELECT
-/// statements.
+/// Simple SQL engine capable of executing a subset of SQL statements.
 pub struct SqlEngine {
     dialect: GenericDialect,
 }
@@ -26,7 +32,9 @@ pub struct SqlEngine {
 impl SqlEngine {
     /// Create a new [`SqlEngine`].
     pub fn new() -> Self {
-        Self { dialect: GenericDialect {} }
+        Self {
+            dialect: GenericDialect {},
+        }
     }
 
     /// Parse `sql` into a list of statements.
@@ -43,60 +51,476 @@ impl SqlEngine {
         let stmts = self.parse(sql)?;
         let mut result = None;
         for stmt in stmts {
-            match stmt {
-                Statement::Insert(insert) => {
-                    let source = insert.source.ok_or(QueryError::Unsupported)?;
-                    let values = match *source.body {
-                        SetExpr::Values(v) => v,
-                        _ => return Err(QueryError::Unsupported),
-                    };
-                    let row = values.rows.get(0).ok_or(QueryError::Unsupported)?;
-                    if row.len() != 2 {
-                        return Err(QueryError::Unsupported);
-                    }
-                    let key = match &row[0] {
-                        Expr::Value(v) => match &v.value {
-                            Value::SingleQuotedString(s) => s.clone(),
-                            _ => return Err(QueryError::Unsupported),
-                        },
-                        _ => return Err(QueryError::Unsupported),
-                    };
-                    let val = match &row[1] {
-                        Expr::Value(v) => match &v.value {
-                            Value::SingleQuotedString(s) => s.clone(),
-                            _ => return Err(QueryError::Unsupported),
-                        },
-                        _ => return Err(QueryError::Unsupported),
-                    };
-                    db.insert(key, val.into_bytes()).await;
-                }
-                Statement::Query(q) => {
-                    match *q.body {
-                        SetExpr::Select(select) => {
-                            if let Some(cond) = select.selection {
-                                if let Expr::BinaryOp { left, op, right } = cond {
-                                    if op == BinaryOperator::Eq {
-                                        if let (
-                                            Expr::Identifier(id),
-                                            Expr::Value(v),
-                                        ) = (*left, *right)
-                                        {
-                                            if id.value.to_lowercase() == "key" {
-                                                if let Value::SingleQuotedString(s) = v.value {
-                                                    result = db.get(&s).await;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        _ => return Err(QueryError::Unsupported),
-                    }
-                }
-                _ => return Err(QueryError::Unsupported),
-            }
+            result = self.execute_stmt(db, stmt).await?;
         }
         Ok(result)
     }
+
+    async fn execute_stmt<S: Storage + Sync + Send>(
+        &self,
+        db: &Database<S>,
+        stmt: Statement,
+    ) -> Result<Option<Vec<u8>>, QueryError> {
+        match stmt {
+            Statement::Insert(insert) => {
+                self.exec_insert(db, insert).await?;
+                Ok(None)
+            }
+            Statement::Update {
+                table,
+                assignments,
+                selection,
+                ..
+            } => {
+                self.exec_update(db, table, assignments, selection).await?;
+                Ok(None)
+            }
+            Statement::Delete(delete) => {
+                self.exec_delete(db, delete).await?;
+                Ok(None)
+            }
+            Statement::CreateTable(ct) => {
+                let ns = object_name_to_ns(&ct.name).ok_or(QueryError::Unsupported)?;
+                register_table(db, &ns).await;
+                Ok(None)
+            }
+            Statement::CreateDatabase { .. } => Ok(None),
+            Statement::ShowTables { .. } => self.exec_show_tables(db).await,
+            Statement::Drop {
+                object_type: ObjectType::Table,
+                names,
+                ..
+            } => {
+                if let Some(name) = names.first() {
+                    let ns = object_name_to_ns(name).ok_or(QueryError::Unsupported)?;
+                    db.clear_ns(&ns).await;
+                    db.delete_ns("_tables", &ns).await;
+                    Ok(None)
+                } else {
+                    Err(QueryError::Unsupported)
+                }
+            }
+            Statement::Query(q) => self.exec_query(db, q).await,
+            _ => Err(QueryError::Unsupported),
+        }
+    }
+
+    async fn exec_insert<S: Storage + Sync + Send>(
+        &self,
+        db: &Database<S>,
+        insert: Insert,
+    ) -> Result<(), QueryError> {
+        let ns = match &insert.table {
+            sqlparser::ast::TableObject::TableName(name) => {
+                object_name_to_ns(name).ok_or(QueryError::Unsupported)?
+            }
+            _ => return Err(QueryError::Unsupported),
+        };
+        register_table(db, &ns).await;
+        let source = insert.source.ok_or(QueryError::Unsupported)?;
+        let values = match *source.body {
+            SetExpr::Values(v) => v,
+            _ => return Err(QueryError::Unsupported),
+        };
+        let row = values.rows.get(0).ok_or(QueryError::Unsupported)?;
+        if row.len() != 2 {
+            return Err(QueryError::Unsupported);
+        }
+        let key = match &row[0] {
+            Expr::Value(v) => match &v.value {
+                Value::SingleQuotedString(s) => s.clone(),
+                _ => return Err(QueryError::Unsupported),
+            },
+            _ => return Err(QueryError::Unsupported),
+        };
+        let val = match &row[1] {
+            Expr::Value(v) => match &v.value {
+                Value::SingleQuotedString(s) => s.clone(),
+                _ => return Err(QueryError::Unsupported),
+            },
+            _ => return Err(QueryError::Unsupported),
+        };
+        db.insert_ns(&ns, key, val.into_bytes()).await;
+        Ok(())
+    }
+
+    async fn exec_update<S: Storage + Sync + Send>(
+        &self,
+        db: &Database<S>,
+        table: TableWithJoins,
+        assignments: Vec<Assignment>,
+        selection: Option<Expr>,
+    ) -> Result<(), QueryError> {
+        let ns = table_factor_to_ns(&table.relation).ok_or(QueryError::Unsupported)?;
+        register_table(db, &ns).await;
+        let key = if let Some(expr) = selection {
+            if let Expr::BinaryOp { left, op, right } = expr {
+                if op == BinaryOperator::Eq {
+                    if let (Expr::Identifier(id), Expr::Value(v)) = (*left, *right) {
+                        if id.value.to_lowercase() == "key" {
+                            if let Value::SingleQuotedString(s) = v.value {
+                                s
+                            } else {
+                                return Err(QueryError::Unsupported);
+                            }
+                        } else {
+                            return Err(QueryError::Unsupported);
+                        }
+                    } else {
+                        return Err(QueryError::Unsupported);
+                    }
+                } else {
+                    return Err(QueryError::Unsupported);
+                }
+            } else {
+                return Err(QueryError::Unsupported);
+            }
+        } else {
+            return Err(QueryError::Unsupported);
+        };
+        let mut new_val = None;
+        for assign in assignments {
+            if let AssignmentTarget::ColumnName(name) = assign.target {
+                if let Some(id) = name.0.first().and_then(|p| p.as_ident()) {
+                    if id.value.to_lowercase() == "value" {
+                        if let Expr::Value(v) = assign.value {
+                            if let Value::SingleQuotedString(s) = v.value {
+                                new_val = Some(s);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let val = new_val.ok_or(QueryError::Unsupported)?;
+        db.insert_ns(&ns, key, val.into_bytes()).await;
+        Ok(())
+    }
+
+    async fn exec_delete<S: Storage + Sync + Send>(
+        &self,
+        db: &Database<S>,
+        delete: Delete,
+    ) -> Result<(), QueryError> {
+        let table = match &delete.from {
+            FromTable::WithFromKeyword(t) | FromTable::WithoutKeyword(t) => t,
+        };
+        if table.len() != 1 {
+            return Err(QueryError::Unsupported);
+        }
+        let ns = table_factor_to_ns(&table[0].relation).ok_or(QueryError::Unsupported)?;
+        register_table(db, &ns).await;
+        if let Some(expr) = delete.selection {
+            if let Expr::BinaryOp { left, op, right } = expr {
+                if op == BinaryOperator::Eq {
+                    if let (Expr::Identifier(id), Expr::Value(v)) = (*left, *right) {
+                        if id.value.to_lowercase() == "key" {
+                            if let Value::SingleQuotedString(s) = v.value {
+                                db.delete_ns(&ns, &s).await;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn exec_query<S: Storage + Sync + Send>(
+        &self,
+        db: &Database<S>,
+        q: Box<Query>,
+    ) -> Result<Option<Vec<u8>>, QueryError> {
+        match *q.body {
+            SetExpr::Select(select) => {
+                self.exec_select(db, *select, q.order_by, q.limit_clause)
+                    .await
+            }
+            _ => Err(QueryError::Unsupported),
+        }
+    }
+
+    async fn exec_select<S: Storage + Sync + Send>(
+        &self,
+        db: &Database<S>,
+        select: Select,
+        order: Option<OrderBy>,
+        limit: Option<LimitClause>,
+    ) -> Result<Option<Vec<u8>>, QueryError> {
+        if select.from.len() != 1 {
+            return Err(QueryError::Unsupported);
+        }
+        let ns = table_factor_to_ns(&select.from[0].relation).ok_or(QueryError::Unsupported)?;
+        register_table(db, &ns).await;
+        let mut rows = db.scan_ns(&ns).await;
+        if let Some(cond) = select.selection {
+            rows.retain(|(k, v)| eval_cond(&cond, k, v));
+        }
+
+        if let sqlparser::ast::GroupByExpr::Expressions(exprs, _) = &select.group_by {
+            if !exprs.is_empty() {
+                return self.exec_group_select(exprs, &select.projection, rows, limit);
+            }
+        }
+
+        if select.distinct.is_some() {
+            rows.sort_by(|a, b| a.cmp(b));
+            rows.dedup();
+        }
+
+        if let Some(order) = order {
+            if let OrderByKind::Expressions(exprs) = order.kind {
+                if let Some(ob) = exprs.first() {
+                    let asc = ob.options.asc.unwrap_or(true);
+                    if let Expr::Identifier(id) = &ob.expr {
+                        let col = id.value.to_lowercase();
+                        rows.sort_by(|a, b| {
+                            let av = column_value(&col, &a.0, &a.1);
+                            let bv = column_value(&col, &b.0, &b.1);
+                            if asc { av.cmp(&bv) } else { bv.cmp(&av) }
+                        });
+                    }
+                }
+            }
+        }
+
+        if let Some(lc) = limit {
+            apply_limit_rows(&mut rows, &lc);
+        }
+
+        if select.projection.len() != 1 {
+            return Err(QueryError::Unsupported);
+        }
+        let item = &select.projection[0];
+        let result = match item {
+            SelectItem::Wildcard(_) => rows.first().map(|(_, v)| v.clone()),
+            SelectItem::UnnamedExpr(Expr::Function(func)) => {
+                Some(handle_function(func, &rows)?)
+            }
+            SelectItem::UnnamedExpr(expr) => {
+                let mut out: Vec<String> = rows
+                    .iter()
+                    .filter_map(|(k, v)| eval_expr(expr, k, v))
+                    .collect();
+                if select.distinct.is_some() {
+                    out.sort();
+                    out.dedup();
+                }
+                out.first().map(|s| s.clone().into_bytes())
+            }
+            _ => return Err(QueryError::Unsupported),
+        };
+        Ok(result)
+    }
+
+    fn exec_group_select(
+        &self,
+        group_exprs: &Vec<Expr>,
+        projection: &Vec<SelectItem>,
+        rows: Vec<(String, Vec<u8>)>,
+        limit: Option<LimitClause>,
+    ) -> Result<Option<Vec<u8>>, QueryError> {
+        if group_exprs.len() != 1 || projection.len() != 1 {
+            return Err(QueryError::Unsupported);
+        }
+        let group_expr = &group_exprs[0];
+        let mut groups: BTreeMap<String, Vec<(String, Vec<u8>)>> = BTreeMap::new();
+        for (k, v) in rows {
+            if let Some(key) = eval_expr(group_expr, &k, &v) {
+                groups.entry(key).or_default().push((k, v));
+            }
+        }
+        let item = &projection[0];
+        let mut out: Vec<Vec<u8>> = Vec::new();
+        for (gk, grp_rows) in groups {
+            let val = match item {
+                SelectItem::Wildcard(_) => gk.into_bytes(),
+                SelectItem::UnnamedExpr(Expr::Function(func)) => {
+                    handle_function(func, &grp_rows)?
+                }
+                SelectItem::UnnamedExpr(expr) => {
+                    eval_expr(expr, &grp_rows[0].0, &grp_rows[0].1)
+                        .unwrap_or_default()
+                        .into_bytes()
+                }
+                _ => return Err(QueryError::Unsupported),
+            };
+            out.push(val);
+        }
+        if let Some(lc) = limit {
+            apply_limit_vec(&mut out, &lc);
+        }
+        Ok(out.into_iter().next())
+    }
+
+    async fn exec_show_tables<S: Storage + Sync + Send>(
+        &self,
+        db: &Database<S>,
+    ) -> Result<Option<Vec<u8>>, QueryError> {
+        let mut tables: Vec<String> =
+            db.scan_ns("_tables").await.into_iter().map(|(k, _)| k).collect();
+        tables.sort();
+        Ok(Some(tables.join("\n").into_bytes()))
+    }
 }
+
+async fn register_table<S: Storage + Sync + Send>(db: &Database<S>, table: &str) {
+    if db.get_ns("_tables", table).await.is_none() {
+        db.insert_ns("_tables", table.to_string(), Vec::new()).await;
+    }
+}
+
+fn object_name_to_ns(name: &ObjectName) -> Option<String> {
+    name
+        .0
+        .last()
+        .and_then(|p| p.as_ident())
+        .map(|i| i.value.to_lowercase())
+}
+
+fn table_factor_to_ns(tf: &TableFactor) -> Option<String> {
+    match tf {
+        TableFactor::Table { name, .. } => object_name_to_ns(name),
+        _ => None,
+    }
+}
+
+fn column_value(col: &str, key: &str, val: &[u8]) -> String {
+    if col == "key" {
+        key.to_string()
+    } else {
+        String::from_utf8_lossy(val).to_string()
+    }
+}
+
+fn eval_expr(expr: &Expr, key: &str, val: &[u8]) -> Option<String> {
+    match expr {
+        Expr::Identifier(id) => Some(column_value(&id.value.to_lowercase(), key, val)),
+        Expr::Value(v) => match &v.value {
+            Value::SingleQuotedString(s) => Some(s.clone()),
+            Value::Number(n, _) => Some(n.clone()),
+            _ => None,
+        },
+        Expr::Cast { expr, data_type, .. } => {
+            let inner = eval_expr(expr, key, val)?;
+            match data_type {
+                DataType::Int(_)
+                | DataType::Integer(_)
+                | DataType::BigInt(_)
+                | DataType::SmallInt(_)
+                | DataType::Unsigned => inner.parse::<i64>().ok().map(|i| i.to_string()),
+                DataType::Text | DataType::Varchar(_) | DataType::Char(_) => Some(inner),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn eval_cond(expr: &Expr, key: &str, val: &[u8]) -> bool {
+    match expr {
+        Expr::BinaryOp { left, op, right } => {
+            if let (Some(lhs), Some(rhs)) = (eval_expr(left, key, val), eval_expr(right, key, val)) {
+                match op {
+                    BinaryOperator::Eq => lhs == rhs,
+                    BinaryOperator::NotEq => lhs != rhs,
+                    BinaryOperator::Lt => lhs < rhs,
+                    BinaryOperator::Gt => lhs > rhs,
+                    BinaryOperator::LtEq => lhs <= rhs,
+                    BinaryOperator::GtEq => lhs >= rhs,
+                    BinaryOperator::Custom(op) if op.eq_ignore_ascii_case("contains") => {
+                        lhs.contains(&rhs)
+                    }
+                    _ => false,
+                }
+            } else {
+                false
+            }
+        }
+        Expr::InList {
+            expr,
+            list,
+            negated,
+        } => {
+            if let Some(target) = eval_expr(expr, key, val) {
+                let found = list
+                    .iter()
+                    .any(|e| eval_expr(e, key, val).map_or(false, |s| s == target));
+                if *negated { !found } else { found }
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn handle_function(func: &Function, rows: &[(String, Vec<u8>)]) -> Result<Vec<u8>, QueryError> {
+    let name = func.name.to_string().to_lowercase();
+    match name.as_str() {
+        "count" => Ok(rows.len().to_string().into_bytes()),
+        "min" | "max" => {
+            let expr = extract_func_expr(func)?;
+            let mut vals: Vec<String> =
+                rows.iter().filter_map(|(k, v)| eval_expr(expr, k, v)).collect();
+            vals.sort();
+            if name == "min" {
+                Ok(vals.first().unwrap_or(&"".to_string()).clone().into_bytes())
+            } else {
+                Ok(vals.last().unwrap_or(&"".to_string()).clone().into_bytes())
+            }
+        }
+        "sum" => {
+            let expr = extract_func_expr(func)?;
+            let sum: i64 = rows
+                .iter()
+                .filter_map(|(k, v)| eval_expr(expr, k, v)?.parse::<i64>().ok())
+                .sum();
+            Ok(sum.to_string().into_bytes())
+        }
+        _ => Err(QueryError::Unsupported),
+    }
+}
+
+fn extract_func_expr(func: &Function) -> Result<&Expr, QueryError> {
+    if let FunctionArguments::List(list) = &func.args {
+        if let Some(FunctionArg::Unnamed(FunctionArgExpr::Expr(expr))) = list.args.first() {
+            Ok(expr)
+        } else {
+            Err(QueryError::Unsupported)
+        }
+    } else {
+        Err(QueryError::Unsupported)
+    }
+}
+
+fn extract_limit(lc: &LimitClause) -> Option<usize> {
+    match lc {
+        LimitClause::LimitOffset { limit: Some(Expr::Value(v)), .. } |
+        LimitClause::OffsetCommaLimit { limit: Expr::Value(v), .. } => {
+            if let Value::Number(n, _) = &v.value {
+                n.parse::<usize>().ok()
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn apply_limit_rows(rows: &mut Vec<(String, Vec<u8>)>, lc: &LimitClause) {
+    if let Some(l) = extract_limit(lc) {
+        if rows.len() > l {
+            rows.truncate(l);
+        }
+    }
+}
+
+fn apply_limit_vec<T>(v: &mut Vec<T>, lc: &LimitClause) {
+    if let Some(l) = extract_limit(lc) {
+        if v.len() > l {
+            v.truncate(l);
+        }
+    }
+}
+

--- a/tests/query_advanced_test.rs
+++ b/tests/query_advanced_test.rs
@@ -65,10 +65,6 @@ async fn table_names_group_by_and_cast() {
     let engine = SqlEngine::new();
 
     engine
-        .execute(&db, "CREATE DATABASE foo")
-        .await
-        .unwrap();
-    engine
         .execute(&db, "CREATE TABLE foo.kv")
         .await
         .unwrap();

--- a/tests/query_advanced_test.rs
+++ b/tests/query_advanced_test.rs
@@ -1,0 +1,115 @@
+use lsmt::storage::local::LocalStorage;
+use lsmt::{Database, SqlEngine};
+
+#[tokio::test]
+async fn update_delete_and_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(tmp.path());
+    let db = Database::new(storage);
+    let engine = SqlEngine::new();
+
+    engine
+        .execute(&db, "INSERT INTO kv VALUES ('a','1')")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "UPDATE kv SET value = '2' WHERE key = 'a'")
+        .await
+        .unwrap();
+    let res = engine
+        .execute(&db, "SELECT value FROM kv WHERE key = 'a'")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(String::from_utf8(res).unwrap(), "2");
+
+    engine
+        .execute(&db, "DELETE FROM kv WHERE key = 'a'")
+        .await
+        .unwrap();
+    let res = engine
+        .execute(&db, "SELECT value FROM kv WHERE key = 'a'")
+        .await
+        .unwrap();
+    assert!(res.is_none());
+
+    engine
+        .execute(&db, "INSERT INTO kv VALUES ('b','3')")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "INSERT INTO kv VALUES ('c','4')")
+        .await
+        .unwrap();
+
+    let res = engine
+        .execute(&db, "SELECT COUNT(*) FROM kv")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(String::from_utf8(res).unwrap(), "2");
+
+    let res = engine
+        .execute(&db, "SELECT key FROM kv ORDER BY key DESC LIMIT 1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(String::from_utf8(res).unwrap(), "c");
+}
+
+#[tokio::test]
+async fn table_names_group_by_and_cast() {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = LocalStorage::new(tmp.path());
+    let db = Database::new(storage);
+    let engine = SqlEngine::new();
+
+    engine
+        .execute(&db, "CREATE DATABASE foo")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "CREATE TABLE foo.kv")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "INSERT INTO foo.kv VALUES ('a','001')")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "INSERT INTO foo.kv VALUES ('b','002')")
+        .await
+        .unwrap();
+    engine
+        .execute(&db, "INSERT INTO foo.kv VALUES ('c','001')")
+        .await
+        .unwrap();
+
+    let res = engine
+        .execute(&db, "SELECT value FROM kv WHERE key = 'a'")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(String::from_utf8(res).unwrap(), "001");
+
+    let tables = engine
+        .execute(&db, "SHOW TABLES")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(String::from_utf8(tables).unwrap().trim(), "kv");
+
+    let cast = engine
+        .execute(&db, "SELECT CAST(value AS INT) FROM foo.kv WHERE key = 'a'")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(String::from_utf8(cast).unwrap(), "1");
+
+    let grp = engine
+        .execute(&db, "SELECT COUNT(*) FROM foo.kv GROUP BY value")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(String::from_utf8(grp).unwrap(), "2");
+}


### PR DESCRIPTION
## Summary
- namespace keys by table and expose helper methods on Database and MemTable
- refactor query execution into per-statement handlers and add GROUP BY/CAST support
- add tests covering namespaces, grouping, casting, and SHOW TABLES

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689d80e9af708324acf316e3e90a1628