### PR TITLE
Document SQL queries and add code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ Experimental log-structured merge tree database written in Rust.
 - Basic SQL parsing via [`sqlparser`]
 - Dockerfile and docker-compose for containerized deployment
 
+## Supported Queries
+
+The built-in SQL engine understands a small subset of SQL that is geared
+toward key/value access:
+
+- `INSERT` of a `key`/`value` pair into a table
+- `UPDATE` and `DELETE` statements targeting a single key
+- `SELECT` with optional `WHERE` filters, `ORDER BY`, `GROUP BY`,
+  `DISTINCT`, simple aggregate functions (`COUNT`, `MIN`, `MAX`, `SUM`)
+  and `LIMIT`
+- Table management statements such as `CREATE TABLE`, `DROP TABLE` and
+  `SHOW TABLES`
+
 ## Development
 
 ```bash

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -1,14 +1,23 @@
+/// Simple bloom filter implementation used to provide probabilistic
+/// membership tests for on-disk SSTables.
 pub struct BloomFilter {
+    /// Bit vector storing hashed membership information.
     bits: Vec<bool>,
 }
 
 impl BloomFilter {
+    /// Create a new filter with `size` bits.
     pub fn new(size: usize) -> Self {
         Self { bits: vec![false; size] }
     }
 
+    /// Compute two simple hash values for `item` using a pair of
+    /// different algorithms. These are inexpensive and good enough for
+    /// the toy implementation.
     fn hashes(&self, item: &str) -> (usize, usize) {
+        // djb2 style hash
         let mut h1: u64 = 5381;
+        // second hash accumulates bytes with a different multiplier
         let mut h2: u64 = 0;
         for b in item.bytes() {
             h1 = ((h1 << 5).wrapping_add(h1)).wrapping_add(b as u64);
@@ -18,12 +27,15 @@ impl BloomFilter {
         ((h1 % len) as usize, (h2 % len) as usize)
     }
 
+    /// Record `item` in the filter.
     pub fn insert(&mut self, item: &str) {
         let (a, b) = self.hashes(item);
         self.bits[a] = true;
         self.bits[b] = true;
     }
 
+    /// Return `true` if the filter indicates that `item` may be present.
+    /// False positives are possible but false negatives are not.
     pub fn may_contain(&self, item: &str) -> bool {
         let (a, b) = self.hashes(item);
         self.bits.get(a).copied().unwrap_or(false)

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1,29 +1,36 @@
 use std::collections::BTreeMap;
 use tokio::sync::RwLock;
 
+/// Thread-safe in-memory table backed by a `BTreeMap`.
 pub struct MemTable {
+    /// Protected map storing raw key/value pairs.
     data: RwLock<BTreeMap<String, Vec<u8>>>,
 }
 
 impl MemTable {
+    /// Create a new, empty [`MemTable`].
     pub fn new() -> Self {
         Self {
             data: RwLock::new(BTreeMap::new()),
         }
     }
 
+    /// Insert a `key`/`value` pair into the table.
     pub async fn insert(&self, key: String, value: Vec<u8>) {
         self.data.write().await.insert(key, value);
     }
 
+    /// Retrieve the value for `key` if it exists.
     pub async fn get(&self, key: &str) -> Option<Vec<u8>> {
         self.data.read().await.get(key).cloned()
     }
 
+    /// Remove a `key` from the table.
     pub async fn delete(&self, key: &str) {
         self.data.write().await.remove(key);
     }
 
+    /// Return all entries currently stored in the table.
     pub async fn scan(&self) -> Vec<(String, Vec<u8>)> {
         self.data
             .read()
@@ -33,21 +40,27 @@ impl MemTable {
             .collect()
     }
 
+    /// Return the number of entries in the table.
     pub async fn len(&self) -> usize {
         self.data.read().await.len()
     }
 
+    /// Remove all entries from the table.
     pub async fn clear(&self) {
         self.data.write().await.clear();
     }
 
+    /// Delete every key that begins with `prefix`.
     pub async fn delete_prefix(&self, prefix: &str) {
         let mut data = self.data.write().await;
+        // Collect matching keys first to avoid holding references while
+        // mutating the map.
         let keys: Vec<String> = data
             .keys()
             .filter(|k| k.starts_with(prefix))
             .cloned()
             .collect();
+        // Remove each key individually.
         for k in keys {
             data.remove(&k);
         }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -1,18 +1,24 @@
 use std::{fs::File, io::Write, path::PathBuf};
 use tokio::sync::Mutex;
 
+/// Basic write-ahead log used to persist recent writes before they are
+/// flushed to disk.
 pub struct Wal {
+    /// Path to the log file.
     path: PathBuf,
+    /// File handle protected by a mutex for async access.
     file: Mutex<File>,
 }
 
 impl Wal {
+    /// Create a new log at `path`.
     pub fn new(path: impl Into<PathBuf>) -> std::io::Result<Self> {
         let path = path.into();
         let file = File::create(&path)?;
         Ok(Self { path, file: Mutex::new(file) })
     }
 
+    /// Append a line of `data` to the log and flush it to disk.
     pub async fn append(&self, data: &[u8]) -> std::io::Result<()> {
         let mut file = self.file.lock().await;
         file.write_all(data)?;
@@ -22,6 +28,7 @@ impl Wal {
     }
 }
 
+/// Create `shards` independent WAL files using `base` as the prefix.
 pub fn shard_wal(base: &str, shards: usize) -> Vec<Wal> {
     (0..shards)
         .map(|i| Wal::new(format!("{base}_{i}.wal")).expect("create wal"))

--- a/src/zonemap.rs
+++ b/src/zonemap.rs
@@ -1,23 +1,30 @@
+/// Zone map summarizing the minimum and maximum keys seen.
 #[derive(Default)]
 pub struct ZoneMap {
+    /// Smallest key observed.
     pub min: Option<String>,
+    /// Largest key observed.
     pub max: Option<String>,
 }
 
 impl ZoneMap {
+    /// Update the zone map with a new `key`.
     pub fn update(&mut self, key: &str) {
         match self.min.as_deref() {
             Some(min) if key < min => self.min = Some(key.to_string()),
             None => self.min = Some(key.to_string()),
-            _ => {}
+            _ => {},
         }
         match self.max.as_deref() {
             Some(max) if key > max => self.max = Some(key.to_string()),
             None => self.max = Some(key.to_string()),
-            _ => {}
+            _ => {},
         }
     }
 
+    /// Return `true` if `key` lies within the stored bounds. When bounds
+    /// are missing the function defaults to `true` so as not to filter
+    /// out potential matches.
     pub fn contains(&self, key: &str) -> bool {
         match (self.min.as_deref(), self.max.as_deref()) {
             (Some(min), Some(max)) => key >= min && key <= max,
@@ -25,3 +32,4 @@ impl ZoneMap {
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- describe supported SQL queries in README
- add docstrings and inline comments across storage and query modules

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_689e09ec7d988324a1648e1756531c5f