### PR TITLE
Integrate write-ahead log into LSM tree

### DIFF
--- a/src/wal.rs
+++ b/src/wal.rs
@@ -1,4 +1,9 @@
-use std::{fs::File, io::Write, path::PathBuf};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use std::{
+    fs::{File, OpenOptions},
+    io::{Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
 use tokio::sync::Mutex;
 
 /// Basic write-ahead log used to persist recent writes before they are
@@ -11,11 +16,20 @@ pub struct Wal {
 }
 
 impl Wal {
-    /// Create a new log at `path`.
+    /// Create or open a log at `path`.
+    ///
+    /// The log is opened in append mode so new entries are added to the end.
     pub fn new(path: impl Into<PathBuf>) -> std::io::Result<Self> {
         let path = path.into();
-        let file = File::create(&path)?;
-        Ok(Self { path, file: Mutex::new(file) })
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .read(true)
+            .open(&path)?;
+        Ok(Self {
+            path,
+            file: Mutex::new(file),
+        })
     }
 
     /// Append a line of `data` to the log and flush it to disk.
@@ -25,6 +39,44 @@ impl Wal {
         file.write_all(b"\n")?;
         file.flush()?;
         Ok(())
+    }
+
+    /// Remove all data from the log by truncating the underlying file.
+    pub async fn clear(&self) -> std::io::Result<()> {
+        let mut file = self.file.lock().await;
+        file.set_len(0)?;
+        file.seek(SeekFrom::Start(0))?;
+        Ok(())
+    }
+
+    /// Load all entries currently stored in the log.
+    ///
+    /// Each line is expected to be of the form `key\tbase64(value)` and will
+    /// be decoded into a tuple of `(key, value)`.
+    pub fn load(path: impl AsRef<Path>) -> std::io::Result<Vec<(String, Vec<u8>)>> {
+        let mut res = Vec::new();
+        let mut buf = Vec::new();
+        let mut file = match File::open(path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(res),
+            Err(e) => return Err(e),
+        };
+        file.read_to_end(&mut buf)?;
+        for line in buf.split(|b| *b == b'\n') {
+            if line.is_empty() {
+                continue;
+            }
+            if let Some(pos) = line.iter().position(|b| *b == b'\t') {
+                let key = std::str::from_utf8(&line[..pos])
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+                    .to_string();
+                let val = STANDARD
+                    .decode(&line[pos + 1..])
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                res.push((key, val));
+            }
+        }
+        Ok(res)
     }
 }
 

--- a/tests/e2e_local.rs
+++ b/tests/e2e_local.rs
@@ -1,10 +1,11 @@
-use lsmt::{storage::local::LocalStorage, Database, SqlEngine};
+use lsmt::{Database, SqlEngine, storage::local::LocalStorage};
 
 #[tokio::test]
 async fn e2e_insert_select() {
     let dir = tempfile::tempdir().unwrap();
     let storage = LocalStorage::new(dir.path());
-    let db = Database::new(storage);
+    let wal = dir.path().join("wal.log");
+    let db = Database::new(storage, wal).await;
     let engine = SqlEngine::new();
     engine
         .execute(&db, "INSERT INTO kv VALUES ('foo','bar')")

--- a/tests/lsm_flush_test.rs
+++ b/tests/lsm_flush_test.rs
@@ -4,7 +4,8 @@ use lsmt::{Database, storage::local::LocalStorage};
 async fn flush_and_query_from_sstable() {
     let dir = tempfile::tempdir().unwrap();
     let storage = LocalStorage::new(dir.path());
-    let db = Database::new(storage);
+    let wal = dir.path().join("wal.log");
+    let db = Database::new(storage, wal).await;
 
     db.insert("k1".to_string(), b"v1".to_vec()).await;
     db.insert("k2".to_string(), b"v2".to_vec()).await;

--- a/tests/wal_recovery_test.rs
+++ b/tests/wal_recovery_test.rs
@@ -1,0 +1,16 @@
+use lsmt::{Database, storage::local::LocalStorage};
+
+#[tokio::test]
+async fn wal_recovery_after_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    let wal = path.join("wal.log");
+    {
+        let storage = LocalStorage::new(&path);
+        let db = Database::new(storage, &wal).await;
+        db.insert("k1".to_string(), b"v1".to_vec()).await;
+    }
+    let storage = LocalStorage::new(&path);
+    let db = Database::new(storage, &wal).await;
+    assert_eq!(db.get("k1").await, Some(b"v1".to_vec()));
+}


### PR DESCRIPTION
## Summary
- persist writes to a simple WAL and replay them on startup
- clear WAL after flushing memtable to SSTable
- wire the server and tests to use the WAL and add recovery test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689e2d4a78208324a5152f84b7e94087