### PR TITLE
Support IN queries across replicas

### DIFF
--- a/tests/replication_http_test.rs
+++ b/tests/replication_http_test.rs
@@ -115,6 +115,17 @@ async fn union_and_lww_across_replicas() {
         .unwrap();
     assert_eq!(res_b, "vb");
 
+    let res_c = client
+        .post(format!("{}/query", base1))
+        .body("SELECT val FROM kv WHERE id IN ('a', 'b')")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert_eq!(res_c, "va2\nvb");
+
     child1.kill().unwrap();
     child2.kill().unwrap();
 }


### PR DESCRIPTION
## Summary
- support selecting multiple keys via SQL `IN` clauses
- verify replica union works with multi-key queries

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a15d1f145c8324a3f7137ba6911d8f