### PR TITLE
Add multi-node docker-compose configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,23 @@ curl -X POST localhost:8080/query -d "INSERT INTO kv VALUES ('hello','world')"
 curl -X POST localhost:8080/query -d "SELECT value FROM kv WHERE key = 'hello'"
 ```
 
+## Docker Compose Cluster
+
+The provided `docker-compose.yml` starts a three-node cluster using local
+storage with a replication factor of two.
+
+Start the cluster:
+
+```bash
+docker compose up -d
+```
+
+Insert via one node and query from the others:
+
+```bash
+curl -X POST localhost:8080/query -d "INSERT INTO kv VALUES ('hello','world')"
+curl -X POST localhost:8081/query -d "SELECT value FROM kv WHERE key = 'hello'"
+curl -X POST localhost:8082/query -d "SELECT value FROM kv WHERE key = 'hello'"
+```
+
 The project is a scaffold and many components are left for future work.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,55 @@
 version: '3.8'
 services:
-  lsmt:
+  lsmt1:
     build: .
     volumes:
-      - ./data:/data
-    environment:
-      - LSMT_DATA=/data
+      - ./data1:/data
+    command:
+      - "--node-addr"
+      - "http://lsmt1:8080"
+      - "--peer"
+      - "http://lsmt2:8080"
+      - "--peer"
+      - "http://lsmt3:8080"
+      - "--data-dir"
+      - "/data"
+      - "--rf"
+      - "2"
     ports:
       - "8080:8080"
+
+  lsmt2:
+    build: .
+    volumes:
+      - ./data2:/data
+    command:
+      - "--node-addr"
+      - "http://lsmt2:8080"
+      - "--peer"
+      - "http://lsmt1:8080"
+      - "--peer"
+      - "http://lsmt3:8080"
+      - "--data-dir"
+      - "/data"
+      - "--rf"
+      - "2"
+    ports:
+      - "8081:8080"
+
+  lsmt3:
+    build: .
+    volumes:
+      - ./data3:/data
+    command:
+      - "--node-addr"
+      - "http://lsmt3:8080"
+      - "--peer"
+      - "http://lsmt1:8080"
+      - "--peer"
+      - "http://lsmt2:8080"
+      - "--data-dir"
+      - "/data"
+      - "--rf"
+      - "2"
+    ports:
+      - "8082:8080"


### PR DESCRIPTION
## Summary
- Expand docker-compose to run three lsmt nodes with local storage and RF=2
- Document how to start the cluster and issue queries across nodes

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a1686c8244832487450404e1c4e16c